### PR TITLE
feat: Add Dockerfile for RunPod Serverless deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# Base image from RunPod - choose one with PyTorch, Python 3.10, and CUDA 12.1
+# Example: runpod/pytorch:2.2.1-py3.10-cuda12.1.1-devel-ubuntu22.04
+# Using a more generic reference that RunPod might resolve or a specific one:
+FROM runpod/pytorch:2.2.1-py3.10-cuda12.1.1-devel-ubuntu22.04
+
+# Set environment variables
+ENV LANG=C.UTF-8     LC_ALL=C.UTF-8     PYTHONUNBUFFERED=1     DEBIAN_FRONTEND=noninteractive     RUNPOD_PROJECT_ROOT=/app
+
+# Install git (needed for pip install git+... if not in base image, -devel images usually have it)
+# Also update package lists and install build-essential if needed for Apex, though -devel should have it.
+RUN apt-get update && apt-get install -y --no-install-recommends     git     && rm -rf /var/lib/apt/lists/*
+
+# Create a working directory
+WORKDIR ${RUNPOD_PROJECT_ROOT}
+
+# Copy the entire project repository content
+COPY . .
+
+# Make runpod.sh executable and run it to install Apex
+# This bakes Apex into the Docker image.
+RUN chmod +x ./runpod.sh && ./runpod.sh
+
+# Install Python dependencies
+# Ensure pip is up-to-date first
+RUN python -m pip install --upgrade pip     && python -m pip install --no-cache-dir -r requirements.txt
+
+# Expose the port RunPod expects for the handler (if applicable, often not needed for serverless)
+# EXPOSE 8000
+
+# Set the default command.
+# For RunPod serverless, the environment often looks for handler.py.
+# The base RunPod images usually have an entrypoint that handles invoking the handler.
+# If not, a CMD like ["python", "-u", "handler.py"] might be needed,
+# or a specific RunPod entrypoint script.
+# For now, relying on RunPod's standard Python worker behavior.
+# If a specific CMD is required by RunPod for custom images, this might need adjustment.
+# Often, the base image's ENTRYPOINT handles this.
+# No specific CMD needed here if handler.py is automatically picked up.
+# A simple CMD to keep the container running if necessary:
+# CMD ["sleep", "infinity"]
+# However, usually, the base image's entrypoint handles the worker lifecycle.
+
+# Verify handler.py exists (optional sanity check for logs)
+RUN if [ ! -f "/app/handler.py" ]; then echo "handler.py not found in /app!" && exit 1; fi
+
+# The actual invocation of handler.py is typically managed by RunPod's infrastructure
+# for serverless functions, using their standard Python worker entrypoint.

--- a/runpod.sh
+++ b/runpod.sh
@@ -2,20 +2,14 @@
 
 set -ex # Exit immediately if a command exits with a non-zero status, and print commands.
 
-# Update package lists and install git if not present (it usually is)
-# apt-get update && apt-get install -y git # Might not be needed if base image has it
-
-# Install NVIDIA Apex from source
-# This is often necessary because pip wheels for apex can be outdated or not available for all CUDA/Python versions.
+echo "Installing NVIDIA Apex from source..."
 # Using --no-cache-dir to ensure it rebuilds if needed.
 # The --global-option flags are for older pip versions with apex, might not be needed for newer pip/apex but kept for safety.
-echo "Installing NVIDIA Apex..."
+# Ensure that build essentials (like g++, make) and the correct CUDA toolkit are available
+# in the Docker base image for this to succeed. The chosen -devel image should suffice.
 pip install git+https://github.com/NVIDIA/apex.git --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext"
 
-# Check if apex is installed and usable by Python
-python -c "import apex; print('Apex imported successfully')"
+echo "Verifying Apex installation..."
+python -c "import apex; print('Apex imported successfully and can be found by Python.')"
 
-echo "Apex installation attempted."
-echo "RunPod setup script completed."
-
-# The handler.py will then be called by the RunPod environment.
+echo "NVIDIA Apex installation script (part of Docker build) completed."


### PR DESCRIPTION
This commit introduces a Dockerfile to create a custom environment for deploying the SeedVR project on RunPod Serverless. This provides a more robust and reproducible setup.

Key changes:

1.  **`Dockerfile`**:
    - Added a new `Dockerfile` in the project root.
    - Uses `runpod/pytorch:2.2.1-py3.10-cuda12.1.1-devel-ubuntu22.04` as the base image, providing Python 3.10 and CUDA 12.1.
    - Installs `git`.
    - Copies project files into the `/app` directory in the image.
    - Executes `runpod.sh` during the build process to compile and install NVIDIA Apex, baking it into the image.
    - Installs all Python dependencies from `requirements.txt`.
    - Relies on RunPod's standard Python mechanisms to execute `handler.py`.

2.  **`runpod.sh`**:
    - Simplified to focus solely on installing NVIDIA Apex.
    - Comments updated to reflect its execution during the Docker build phase.
    - Redundant operations (like apt-get) removed as they are handled in the Dockerfile.

**Deployment on RunPod Serverless:**
- You should now build this `Dockerfile` and push the resulting image to a container registry accessible by RunPod (e.g., Docker Hub, AWS ECR, GCP Artifact Registry).
- The RunPod Serverless endpoint should be configured to use this custom Docker image.
- GPU requirements (high-memory, e.g., H100 80GB) remain critical.
- Environment variables (`HF_TOKEN`, `MODEL_REPO_ID`) can be set in the RunPod configuration.
- Input format for jobs remains the same (JSON with `video_url`, etc.).

This approach ensures that all dependencies, including compiled ones like Apex, are correctly installed and versioned within the execution environment.